### PR TITLE
:metal: Drop support for ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9
   - 2.0.0
   - 2.1.10
   - 2.2.4

--- a/rubocop-select.gemspec
+++ b/rubocop-select.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Pipe between git diff and rubocop.'
   spec.homepage      = 'https://github.com/packsaddle/rubocop-select'
   spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.files         = `git ls-files -z`
     .split("\x0")


### PR DESCRIPTION
rubocop drops support for ruby 1.9